### PR TITLE
use error defines from whdvfs.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ else
 # Amiga* targets
 # too lazy to construct AS for gcc/sas
 AS	= vasmm68k_mot -Fhunk -I$(INCLUDEOS3) -quiet
-ifeq ($(TARGET),Amiga)
+ifeq ($(TARGET),AmigaV)
 CC	= vc
 CFLAGS	= -Ilibrary -I. -I$(INCLUDEOS3) -sc -O2
 CFSPEED	= -speed
@@ -61,9 +61,11 @@ LDFLAGS = Link SmallData SmallCode
 MKLIB	= $(VAMOS) slink SmallData SmallCode Quiet Lib lib:sc.lib To $@ From $^
 CCVER	= $(VAMOS) sc | awk '/^SAS/ { printf " "$$0 }'
 endif
+ifeq ($(CCVER),)
+$(error supported TARGETs are AmigaG, AmigaS, AmigaV)
+endif
 INTEGRATION_OBJ = archivefs_integration_amiga.o
 LIB	= WHDLoad.VFS
-
 endif
 
 PROG	= test

--- a/library/archivefs_api.c
+++ b/library/archivefs_api.c
@@ -104,7 +104,7 @@ int archivefs_initialize(void **_archive,const char *filename)
 		archivefs_integration_fileClose(combinedState->archive.file);
 		archivefs_integration_uninitialize();
 		*_archive=0;
-		return ARCHIVEFS_ERROR_MEMORY_ALLOCATION_FAILED;
+		return WVFS_ERROR_MEMORY_ALLOCATION_FAILED;
 	}
 
 	combinedState->archive.file=file;
@@ -179,9 +179,9 @@ uint32_t archivefs_getFileSize(void *_archive,const char *name)
 
 	entry=archivefs_findEntry(archive,name);
 	if (!entry)
-		return ARCHIVEFS_ERROR_FILE_NOT_FOUND;
+		return WVFS_ERROR_FILE_NOT_FOUND;
 	if (entry->fileType!=ARCHIVEFS_TYPE_FILE)
-		return ARCHIVEFS_ERROR_INVALID_FILE_TYPE;
+		return WVFS_ERROR_INVALID_FILE_TYPE;
 	return entry->length;
 }
 
@@ -200,7 +200,7 @@ int archivefs_fileCache(void *_archive,archivefs_allocFile fileFunc)
 		if (tmp->fileType==ARCHIVEFS_TYPE_FILE)
 		{
 			ptr=fileFunc(tmp->pathAndName,tmp->length);
-			if (!ptr) return ARCHIVEFS_ERROR_OPERATION_CANCELED;
+			if (!ptr) return WVFS_ERROR_OPERATION_CANCELED;
 			if (((long)ptr)!=-1)
 			{
 				ret=archivefs_fileReadRaw(combined,ptr,tmp,tmp->length,0,1);
@@ -226,7 +226,7 @@ int archivefs_dirCache(void *_archive,archivefs_registerEntry registerFunc)
 	{
 		archivefs_createFIB(&fib,tmp);
 		ret=registerFunc(tmp->pathAndName,&fib);
-		if (!ret) return ARCHIVEFS_ERROR_OPERATION_CANCELED;
+		if (!ret) return WVFS_ERROR_OPERATION_CANCELED;
 		tmp=tmp->next;
 	}
 	return 0;
@@ -246,9 +246,9 @@ int32_t archivefs_fileRead(void *_archive,void *dest,const char *name,uint32_t l
 	{
 		entry=archivefs_findEntry(archive,name);
 		if (!entry)
-			return ARCHIVEFS_ERROR_FILE_NOT_FOUND;
+			return WVFS_ERROR_FILE_NOT_FOUND;
 		if (entry->fileType!=ARCHIVEFS_TYPE_FILE)
-			return ARCHIVEFS_ERROR_INVALID_FILE_TYPE;
+			return WVFS_ERROR_INVALID_FILE_TYPE;
 	} else {
 		entry=combined->currentFile;
 	}

--- a/library/archivefs_api.h
+++ b/library/archivefs_api.h
@@ -3,6 +3,15 @@
 #ifndef ARCHIVEFS_API_H
 #define ARCHIVEFS_API_H
 
+#ifndef EXEC_TYPES_H
+#define EXEC_TYPES_H
+typedef int LONG;
+typedef unsigned int ULONG;
+typedef void * APTR;
+typedef char * CPTR;
+#endif
+
+#include "whdvfs.h"
 
 /*
    in order not to depend on any external headers
@@ -37,19 +46,6 @@ typedef signed char int8_t;
 #define ARCHIVEFS_ALLOW_NON_AMIGA_ARCHIVES 1
 */
 
-/*
-   Error codes returned by the archivefs_* functions
-*/
-#define ARCHIVEFS_ERROR_INVALID_FORMAT (-1)
-#define ARCHIVEFS_ERROR_UNSUPPORTED_FORMAT (-2)
-#define ARCHIVEFS_ERROR_MEMORY_ALLOCATION_FAILED (-3)
-#define ARCHIVEFS_ERROR_FILE_NOT_FOUND (-4)
-#define ARCHIVEFS_ERROR_NON_AMIGA_ARCHIVE (-5)
-#define ARCHIVEFS_ERROR_INVALID_FILE_TYPE (-6)
-#define ARCHIVEFS_ERROR_DECOMPRESSION_ERROR (-7)
-#define ARCHIVEFS_ERROR_INVALID_READ (-8)
-#define ARCHIVEFS_ERROR_OPERATION_CANCELED (-9)
-
 /* callback functions for the API */
 
 /*
@@ -58,7 +54,7 @@ typedef signed char int8_t;
 	* name - name of the file, including path
 	* length - length of the file
    Returns:
-	* null - when no more files are wanted. i.e. terminate the archivefs_fileCache. fileCache will return with ARCHIVEFS_ERROR_OPERATION_CANCELED error
+	* null - when no more files are wanted. i.e. terminate the archivefs_fileCache. fileCache will return with WVFS_ERROR_OPERATION_CANCELED error
 	* -1 casted as void* - skip this file
 	* any other pointer - allocated buffer of at least file length where the file is requested to read into
 */
@@ -70,7 +66,7 @@ typedef void *(*archivefs_allocFile)(const char *name,uint32_t length);
 	* fullpath - path and filename of the file
 	* fib - pointer to the 232-byte fib structure for the entry
    Returns:
-	* 0 - stop processing further entries. dirCache will return with ARCHIVEFS_ERROR_OPERATION_CANCELED error
+	* 0 - stop processing further entries. dirCache will return with WVFS_ERROR_OPERATION_CANCELED error
 	* -1 (or any nonzero value) - continue processing
 */
 typedef int (*archivefs_registerEntry)(const char *fullpath,const void *fib);
@@ -88,10 +84,10 @@ typedef void (*archivefs_progressIndicator)(uint32_t current,uint32_t max);
 	* error code or 0 if success. In case error occured all allocated memory is freed
    Notable error codes:
 	* Pass through errors from archivefs_integration
-	* ARCHIVEFS_ERROR_INVALID_FORMAT - file could not be parsed
-	* ARCHIVEFS_ERROR_UNSUPPORTED_FORMAT - file format not supported
-	* ARCHIVEFS_ERROR_MEMORY_ALLOCATION_FAILED - Failed to allocate memory
-	* ARCHIVEFS_ERROR_NON_AMIGA_ARCHIVE - Archive is not created in Amiga OS
+	* WVFS_ERROR_INVALID_FORMAT - file could not be parsed
+	* WVFS_ERROR_UNSUPPORTED_FORMAT - file format not supported
+	* WVFS_ERROR_MEMORY_ALLOCATION_FAILED - Failed to allocate memory
+	* WVFS_ERROR_NON_AMIGA_ARCHIVE - Archive is not created in Amiga OS
 */
 int archivefs_initialize(void **archive,const char *filename);
 
@@ -114,8 +110,8 @@ int archivefs_uninitialize(void *archive);
    Returns:
 	* error code or file size if success
    Notable error codes:
-	* ARCHIVEFS_ERROR_FILE_NOT_FOUND - file does not exist
-	* ARCHIVEFS_ERROR_INVALID_FILE_TYPE - filename points to non-file (f.e. directory)
+	* WVFS_ERROR_FILE_NOT_FOUND - file does not exist
+	* WVFS_ERROR_INVALID_FILE_TYPE - filename points to non-file (f.e. directory)
 */
 uint32_t archivefs_getFileSize(void *archive,const char *name);
 
@@ -131,9 +127,9 @@ uint32_t archivefs_getFileSize(void *archive,const char *name);
 	* error code or 0 if success. If error is returned, the last file might not have been read to the buffer
    Notable error codes:
 	* Pass through errors from archivefs_integration
-	* ARCHIVEFS_ERROR_INVALID_FORMAT - file could not be parsed
-	* ARCHIVEFS_ERROR_DECOMPRESSION_ERROR - failed to decompress the file
-	* ARCHIVEFS_ERROR_OPERATION_CANCELED - callback returned stop condition
+	* WVFS_ERROR_INVALID_FORMAT - file could not be parsed
+	* WVFS_ERROR_DECOMPRESSION_ERROR - failed to decompress the file
+	* WVFS_ERROR_OPERATION_CANCELED - callback returned stop condition
 */
 int archivefs_fileCache(void *archive,archivefs_allocFile fileFunc);
 
@@ -146,7 +142,7 @@ int archivefs_fileCache(void *archive,archivefs_allocFile fileFunc);
    Returns:
 	* error code or 0 if success.
    Notable error codes:
-	* ARCHIVEFS_ERROR_OPERATION_CANCELED - callback returned stop condition
+	* WVFS_ERROR_OPERATION_CANCELED - callback returned stop condition
 */
 int archivefs_dirCache(void *archive,archivefs_registerEntry registerFunc);
 
@@ -163,10 +159,10 @@ int archivefs_dirCache(void *archive,archivefs_registerEntry registerFunc);
 	* error code or bytes read if success.
    Notable error codes:
 	* Pass through errors from archivefs_integration
-	* ARCHIVEFS_ERROR_FILE_NOT_FOUND - file does not exist
-	* ARCHIVEFS_ERROR_INVALID_FILE_TYPE - filename points to non-file (f.e. directory)
-	* ARCHIVEFS_ERROR_DECOMPRESSION_ERROR - failed to decompress the file
-	* ARCHIVEFS_ERROR_INVALID_READ - offset and/or length is not valid for this file
+	* WVFS_ERROR_FILE_NOT_FOUND - file does not exist
+	* WVFS_ERROR_INVALID_FILE_TYPE - filename points to non-file (f.e. directory)
+	* WVFS_ERROR_DECOMPRESSION_ERROR - failed to decompress the file
+	* WVFS_ERROR_INVALID_READ - offset and/or length is not valid for this file
 */
 int32_t archivefs_fileRead(void *archive,void *dest,const char *name,uint32_t length,uint32_t offset);
 

--- a/library/archivefs_common.c
+++ b/library/archivefs_common.c
@@ -16,7 +16,7 @@ static int32_t archivefs_common_readPartial(void *dest,int32_t length,uint32_t o
 	ret=archivefs_integration_fileRead(dest,length,archive->file);
 	if (ret<0) return ret;
 	archive->filePos+=ret;
-	if (ret!=length) return ARCHIVEFS_ERROR_INVALID_FORMAT;
+	if (ret!=length) return WVFS_ERROR_INVALID_FORMAT;
 	return length;
 }
 
@@ -87,7 +87,7 @@ int archivefs_common_readBlockBuffer(uint32_t blockIndex,struct archivefs_state 
 		{
 			archive->blockPos=0;
 			archive->blockLength=0;
-			return ARCHIVEFS_ERROR_INVALID_FORMAT;
+			return WVFS_ERROR_INVALID_FORMAT;
 		}
 		return 0;
 	} else {
@@ -102,7 +102,7 @@ int archivefs_common_initBlockBuffer(uint32_t offset,struct archivefs_state *arc
 	uint32_t blockIndex=offset>>archive->blockShift;
 
 	if (offset>=archive->fileLength)
-		return ARCHIVEFS_ERROR_INVALID_FORMAT;
+		return WVFS_ERROR_INVALID_FORMAT;
 	archive->blockPos=offset&((1U<<archive->blockShift)-1U);
 	if (blockIndex!=archive->blockIndex && ((int32_t)(archive->blockLength)>0))
 	{
@@ -176,7 +176,7 @@ static int32_t archivefs_common_copyBlock(uint8_t *dest,uint32_t startBlock,uint
 		copyOffset=0;
 	}
 	if (currentBlockLength>archive->blockLength)
-		return ARCHIVEFS_ERROR_INVALID_FORMAT;
+		return WVFS_ERROR_INVALID_FORMAT;
 	archivefs_common_memcpy(dest,archive->blockData+copyOffset,currentBlockLength-copyOffset);
 	return currentBlockLength-copyOffset;
 }

--- a/library/archivefs_header.S
+++ b/library/archivefs_header.S
@@ -1,12 +1,12 @@
 ; Copyright (C) Teemu Suutari
 
+	INCLUDE	whdvfs.i
+
 ; section name must be .text to become first with m68k-amigaos-ld
 
 	SECTION .text,CODE
 
-	moveq	#-1,d0
-	rts
-	dc.b	"WHDLDVFS"
+	WVFS_HEADER
 	dc.w	1	; version
 	dc.w	0	; flags
 	dc.l	_name

--- a/library/archivefs_huffman_decoder.c
+++ b/library/archivefs_huffman_decoder.c
@@ -39,14 +39,14 @@ int archivefs_HuffmanCreateOrderlyTable(uint16_t *nodes,const uint8_t *bitLength
 	{
 		uint8_t length=bitLengths[i];
 		if (length>32U)
-			return ARCHIVEFS_ERROR_DECOMPRESSION_ERROR;
+			return WVFS_ERROR_DECOMPRESSION_ERROR;
 		if (length)
 		{
 			if (length<minDepth) minDepth=length;
 			if (length>maxDepth) maxDepth=length;
 		}
 	}
-	if (!maxDepth) return ARCHIVEFS_ERROR_DECOMPRESSION_ERROR;
+	if (!maxDepth) return WVFS_ERROR_DECOMPRESSION_ERROR;
 
 	for (depth=minDepth;depth<=maxDepth;depth++)
 	{
@@ -55,7 +55,7 @@ int archivefs_HuffmanCreateOrderlyTable(uint16_t *nodes,const uint8_t *bitLength
 			if (bitLengths[i]==depth)
 			{
 				if (!(nodeCount=archivefs_HuffmanInsert(nodes,nodeCount,depth,code>>(maxDepth-depth),i)))
-					return ARCHIVEFS_ERROR_DECOMPRESSION_ERROR;
+					return WVFS_ERROR_DECOMPRESSION_ERROR;
 				code+=1U<<(maxDepth-depth);
 			}
 		}

--- a/library/archivefs_integration_amiga.c
+++ b/library/archivefs_integration_amiga.c
@@ -1,11 +1,11 @@
 /* Copyright (C) Teemu Suutari */
 
-#include "archivefs_integration.h"
-
 #include <exec/memory.h>
 #include <proto/exec.h>
 #include <proto/dos.h>
 #include <stdlib.h>
+
+#include "archivefs_integration.h"
 
 #ifdef ARCHIVEFS_STANDALONE
 struct ExecBase *SysBase=0;
@@ -51,17 +51,17 @@ int archivefs_integration_fileOpen(const char *filename,uint32_t *length,uint8_t
 
 	lock=Lock((unsigned char *) filename,ACCESS_READ);
 	if (!lock)
-		return ARCHIVEFS_ERROR_FILE_NOT_FOUND;
+		return WVFS_ERROR_FILE_NOT_FOUND;
 	success=Examine(lock,&fib);
 	UnLock(lock);
 	if (!success)
-		return ARCHIVEFS_ERROR_FILE_NOT_FOUND;
+		return WVFS_ERROR_FILE_NOT_FOUND;
 	if (fib.fib_DirEntryType>0)
-		return ARCHIVEFS_ERROR_INVALID_FILE_TYPE;
+		return WVFS_ERROR_INVALID_FILE_TYPE;
 
 	fd=Open((unsigned char *) filename,MODE_OLDFILE);
 	if (!fd)
-		return ARCHIVEFS_ERROR_FILE_NOT_FOUND;
+		return WVFS_ERROR_FILE_NOT_FOUND;
 	*file=(void*)fd;
 	*length=fib.fib_Size;
 	/* TODO: real block size */
@@ -87,7 +87,7 @@ int32_t archivefs_integration_fileRead(void *dest,uint32_t length,void *file)
 
 	ret=Read((BPTR)file,dest,length);
 	if (ret<0)
-		return ARCHIVEFS_ERROR_INVALID_FORMAT;
+		return WVFS_ERROR_INVALID_FORMAT;
 	return ret;
 }
 

--- a/library/archivefs_integration_unix.c
+++ b/library/archivefs_integration_unix.c
@@ -34,15 +34,15 @@ int archivefs_integration_fileOpen(const char *filename,uint32_t *length,uint8_t
 
 	fd=open(filename,O_RDONLY);
 	if (fd<0)
-		return ARCHIVEFS_ERROR_FILE_NOT_FOUND;
+		return WVFS_ERROR_FILE_NOT_FOUND;
 	l=lseek(fd,0,SEEK_END);
 	if (l<0)
-		return ARCHIVEFS_ERROR_INVALID_FORMAT;
+		return WVFS_ERROR_INVALID_FORMAT;
 	*length=l;
 	*blockShift=9U;
 	l=lseek(fd,0,SEEK_SET);
 	if (l<0)
-		return ARCHIVEFS_ERROR_INVALID_FORMAT;
+		return WVFS_ERROR_INVALID_FORMAT;
 	*file=(void*)(size_t)fd;
 	return 0;
 }
@@ -58,7 +58,7 @@ int archivefs_integration_fileSeek(uint32_t offset,void *file)
 	int fd=(size_t)file;
 	int ret=lseek(fd,offset,SEEK_SET);
 	if (ret<0)
-		return ARCHIVEFS_ERROR_INVALID_FORMAT;
+		return WVFS_ERROR_INVALID_FORMAT;
 	return 0;
 }
 
@@ -67,7 +67,7 @@ int32_t archivefs_integration_fileRead(void *dest,uint32_t length,void *file)
 	int fd=(size_t)file;
  	int ret=read(fd,dest,length);
 	if (ret<0)
-		return ARCHIVEFS_ERROR_INVALID_FORMAT;
+		return WVFS_ERROR_INVALID_FORMAT;
  	return ret;
 }
 

--- a/library/archivefs_lha_decompressor.c
+++ b/library/archivefs_lha_decompressor.c
@@ -89,7 +89,7 @@ static int archivefs_lhaCreateSimpleTable(struct archivefs_lhaDecompressState *s
 	tableLength=0;
 	archivefs_lhaReadBits(tableLength,bits);
 	if (tableLength>length)
-		return ARCHIVEFS_ERROR_DECOMPRESSION_ERROR;
+		return WVFS_ERROR_DECOMPRESSION_ERROR;
 	if (!tableLength)
 	{
 		value=0;
@@ -113,7 +113,7 @@ static int archivefs_lhaCreateSimpleTable(struct archivefs_lhaDecompressState *s
 				if (tmp) value++;
 			} while (tmp);
 			if (value>32U)
-				return ARCHIVEFS_ERROR_DECOMPRESSION_ERROR;
+				return WVFS_ERROR_DECOMPRESSION_ERROR;
 		}
 		bitLengths[i++]=value;
 		if (i==3U && enableHole)
@@ -121,7 +121,7 @@ static int archivefs_lhaCreateSimpleTable(struct archivefs_lhaDecompressState *s
 			value=0;
 			archivefs_lhaReadBits(value,2U);
 			if (i+value>length)
-				return ARCHIVEFS_ERROR_DECOMPRESSION_ERROR;
+				return WVFS_ERROR_DECOMPRESSION_ERROR;
 			while (value--)
 				bitLengths[i++]=0;
 		}
@@ -195,7 +195,7 @@ static int32_t archivefs_lhaInitializeBlock(struct archivefs_lhaDecompressState 
 			break;
 		}
 		if (i+rep>tableLength)
-			return ARCHIVEFS_ERROR_DECOMPRESSION_ERROR;
+			return WVFS_ERROR_DECOMPRESSION_ERROR;
 		while (rep--)
 			symbols[i++]=value;
 	}

--- a/library/archivefs_zip_decompressor.c
+++ b/library/archivefs_zip_decompressor.c
@@ -111,7 +111,7 @@ static int32_t archivefs_zipInitializeBlock(struct archivefs_zipDecompressState 
 			nlen|=((uint16_t)tmp)<<8U;
 			nlen=~nlen;
 			if (len!=nlen)
-				return ARCHIVEFS_ERROR_DECOMPRESSION_ERROR;
+				return WVFS_ERROR_DECOMPRESSION_ERROR;
 			state->bitsLeft=0;
 			return len;
 		}
@@ -142,7 +142,7 @@ static int32_t archivefs_zipInitializeBlock(struct archivefs_zipDecompressState 
 
 			archivefs_zipReadBits(symbolCount,5U);
 			symbolCount+=257U;
-			if (symbolCount>=287U) return ARCHIVEFS_ERROR_DECOMPRESSION_ERROR;
+			if (symbolCount>=287U) return WVFS_ERROR_DECOMPRESSION_ERROR;
 			archivefs_zipReadBits(distanceCount,5U);
 			distanceCount++;
 			archivefs_zipReadBits(tableLength,4U);
@@ -166,11 +166,11 @@ static int32_t archivefs_zipInitializeBlock(struct archivefs_zipDecompressState 
 				switch (tmp)
 				{
 					case 16:
-					if (!i) return ARCHIVEFS_ERROR_DECOMPRESSION_ERROR;
+					if (!i) return WVFS_ERROR_DECOMPRESSION_ERROR;
 					archivefs_zipReadBits(tmp,2U);
 					tmp+=i+3U;
 					if (tmp>symbolCount+distanceCount)
-						return ARCHIVEFS_ERROR_DECOMPRESSION_ERROR;
+						return WVFS_ERROR_DECOMPRESSION_ERROR;
 					for (;i<tmp;i++)
 						lengthTable[i]=lengthTable[i-1];
 					break;
@@ -179,7 +179,7 @@ static int32_t archivefs_zipInitializeBlock(struct archivefs_zipDecompressState 
 					archivefs_zipReadBits(tmp,3U);
 					tmp+=i+3U;
 					if (tmp>symbolCount+distanceCount)
-						return ARCHIVEFS_ERROR_DECOMPRESSION_ERROR;
+						return WVFS_ERROR_DECOMPRESSION_ERROR;
 					for (;i<tmp;i++)
 						lengthTable[i]=0;
 					break;
@@ -188,7 +188,7 @@ static int32_t archivefs_zipInitializeBlock(struct archivefs_zipDecompressState 
 					archivefs_zipReadBits(tmp,7U);
 					tmp+=i+11U;
 					if (tmp>symbolCount+distanceCount)
-						return ARCHIVEFS_ERROR_DECOMPRESSION_ERROR;
+						return WVFS_ERROR_DECOMPRESSION_ERROR;
 					for (;i<tmp;i++)
 						lengthTable[i]=0;
 					break;
@@ -206,7 +206,7 @@ static int32_t archivefs_zipInitializeBlock(struct archivefs_zipDecompressState 
 		return 1;
 
 		default:
-		return ARCHIVEFS_ERROR_DECOMPRESSION_ERROR;
+		return WVFS_ERROR_DECOMPRESSION_ERROR;
 	}
 }
 
@@ -249,7 +249,7 @@ static int archivefs_zipDecompressFull(struct archivefs_zipDecompressState *stat
 		if (!blockLength)
 		{
 			if (final)
-				return ARCHIVEFS_ERROR_DECOMPRESSION_ERROR;
+				return WVFS_ERROR_DECOMPRESSION_ERROR;
 			archivefs_zipReadBits(final,1U);
 			state->bitsLeft=bitsLeft;
 			state->accumulator=accumulator;
@@ -264,7 +264,7 @@ static int archivefs_zipDecompressFull(struct archivefs_zipDecompressState *stat
 			uint8_t *buffer;
 
 			if (pos+blockLength>length)
-				return ARCHIVEFS_ERROR_DECOMPRESSION_ERROR;
+				return WVFS_ERROR_DECOMPRESSION_ERROR;
 
 			while (bufLength)
 			{
@@ -292,13 +292,13 @@ static int archivefs_zipDecompressFull(struct archivefs_zipDecompressState *stat
 					archivefs_zipReadBits(count,archivefs_zip_LengthBits[symbol]);
 					count+=archivefs_zipLengthAdditions[symbol];
 					if (pos+count>length)
-						return ARCHIVEFS_ERROR_DECOMPRESSION_ERROR;
+						return WVFS_ERROR_DECOMPRESSION_ERROR;
 
 					archivefs_zipHuffmanDecode(code,state->distanceTree);
 					archivefs_zipReadBits(distance,archivefs_zipDistanceBits[code]);
 					distance+=archivefs_zipDistanceAdditions[code];
 					if (distance>pos)
-						return ARCHIVEFS_ERROR_DECOMPRESSION_ERROR;
+						return WVFS_ERROR_DECOMPRESSION_ERROR;
 
 					while (count--)
 					{

--- a/library/archivefs_zip_decompressor_template.h
+++ b/library/archivefs_zip_decompressor_template.h
@@ -35,7 +35,7 @@
 		if (!blockLength)
 		{
 			if (final)
-				return ARCHIVEFS_ERROR_DECOMPRESSION_ERROR;
+				return WVFS_ERROR_DECOMPRESSION_ERROR;
 			archivefs_zipReadBits(final,1U);
 			state->bitsLeft=bitsLeft;
 			state->accumulator=accumulator;
@@ -52,7 +52,7 @@
 #endif
 
 			if (pos+blockLength>length)
-				return ARCHIVEFS_ERROR_DECOMPRESSION_ERROR;
+				return WVFS_ERROR_DECOMPRESSION_ERROR;
 
 			if (pos+bufLength>targetLength) bufLength=targetLength-pos;
 			blockLength-=bufLength;
@@ -90,13 +90,13 @@
 					archivefs_zipReadBits(count,archivefs_zip_LengthBits[symbol]);
 					count+=archivefs_zipLengthAdditions[symbol];
 					if (pos+count>length)
-						return ARCHIVEFS_ERROR_DECOMPRESSION_ERROR;
+						return WVFS_ERROR_DECOMPRESSION_ERROR;
 
 					archivefs_zipHuffmanDecode(code,state->distanceTree);
 					archivefs_zipReadBits(distance,archivefs_zipDistanceBits[code]);
 					distance+=archivefs_zipDistanceAdditions[code];
 					if (distance>pos)
-						return ARCHIVEFS_ERROR_DECOMPRESSION_ERROR;
+						return WVFS_ERROR_DECOMPRESSION_ERROR;
 
 					while (pos<targetLength && count)
 					{

--- a/library/whdvfs.h
+++ b/library/whdvfs.h
@@ -1,0 +1,167 @@
+#ifndef WHDVFS_H
+#define WHDVFS_H
+/*
+** whdvfs.h
+** include file for WHDLoad Virtual File System interface
+** Copyright (C) Teemu Suutari, Wepl
+*/
+
+#ifndef EXEC_TYPES_H
+#include <exec/types.h>
+#endif /* EXEC_TYPES_H */
+
+/*
+** Error codes returned by wvfs_* functions
+*/
+#define WVFS_ERROR_INVALID_FORMAT (-1)		 /* invalid structure of supported file format */
+#define WVFS_ERROR_UNSUPPORTED_FORMAT (-2)	 /* file format is not supported */
+#define WVFS_ERROR_MEMORY_ALLOCATION_FAILED (-3) /* failed to allocate memory */
+#define WVFS_ERROR_FILE_NOT_FOUND (-4)		 /* file does not exist */
+#define WVFS_ERROR_NON_AMIGA_ARCHIVE (-5)
+#define WVFS_ERROR_INVALID_FILE_TYPE (-6)	 /* filename points to non-file (e.g. directory) */
+#define WVFS_ERROR_DECOMPRESSION_ERROR (-7)	 /* failed to decompress a file */
+#define WVFS_ERROR_INVALID_READ (-8)		 /* offset and/or length is not valid for this file */
+#define WVFS_ERROR_OPERATION_CANCELED (-9)	 /* callback returned stop condition */
+
+/*
+** API functions
+*/
+
+/*
+** Initialize wvfs
+**
+** Open given file and check for a supported format.
+** Allocate all required resources to handle the format (e.g. file handle, directory structure,
+** file list, internal state).
+**
+** Parameters:
+**	wvfs - return pointer to APTR wvfs. Will be initialized if successful.
+**	filename - filename of the archive to open
+**
+** Returns:
+**	error code or 0 on success. In case of an error all allocated resources are freed.
+**
+** Notable error codes:
+**	WVFS_ERROR_UNSUPPORTED_FORMAT - file format is not supported
+**	WVFS_ERROR_INVALID_FORMAT - invalid structure of supported file format
+**	WVFS_ERROR_MEMORY_ALLOCATION_FAILED - Failed to allocate memory
+*/
+LONG wvfs_initialize(APTR *wvfs, const CPTR filename);
+
+/*
+** Uninitialize wvfs
+**
+** Free wvfs handle and all allocated resources.
+**
+** Parameters:
+**	wvfs - pointer to handle
+** Returns:
+**	error code or 0 on success
+** Notable error codes:
+**	none
+*/
+LONG wvfs_uninitialize(APTR wvfs);
+
+/*
+** wvfs_registerEntry gets called by wvfs_dirCache for each entry in the archive
+**
+** Parameters:
+**	fullpath - path and filename of the entry
+**	fib - filled FileInfoBlock structure
+** Returns:
+**	0 - stop processing further entries. wvfs_dirCache returns with WVFS_ERROR_OPERATION_CANCELED
+**	-1 - continue processing
+*/
+typedef LONG (*wvfs_registerEntry)(const CPTR fullpath, const void *fib);
+
+/*
+** Get metadata for all entries in archive.
+**
+** Iterate over all directories and files and provide metadata in a dos.FileInfoBlock.
+** WHDLoad will copy the information via the provided function wvfs_registerEntry to a private storage.
+** Function must not allocate any memory!
+**
+** Parameters:
+**	wvfs - pointer to archive
+**	registerFunc - function to call for each entry
+** Returns:
+**	error code or 0 if success
+** Notable error codes:
+**	WVFS_ERROR_OPERATION_CANCELED - callback returned stop condition
+*/
+LONG wvfs_dirCache(APTR wvfs, wvfs_registerEntry registerFunc);
+
+/*
+** wvfs_allocFile gets called by wvfs_fileCache for each file in the archive.
+**
+** Parameters:
+**	fullpath - path and filename of the entry
+**	length - length of the file
+** Returns:
+**	NULL - when no more files are wanted. i.e. terminate wvfs_fileCache with VFS_ERROR_OPERATION_CANCELED
+**	-1 - skip this file
+**	APTR - allocated buffer of at least file length where the file is requested to read into
+*/
+typedef APTR (*wvfs_allocFile)(const CPTR fullpath, ULONG length);
+
+/*
+** Load all files from the archive.
+**
+** wvfs_fileCache will call wvfs_allocFile for each file in the archive and if the function
+** returns a valid pointer the file contents are read to it.
+**
+** Parameters:
+**	wvfs - pointer to archive
+**	fileFunc - function to call for each file
+** Returns:
+**	error code or 0 on success.
+** Notable error codes:
+**	WVFS_ERROR_DECOMPRESSION_ERROR - failed to decompress a file
+**	WVFS_ERROR_OPERATION_CANCELED - callback returned stop condition
+*/
+LONG wvfs_fileCache(APTR wvfs, wvfs_allocFile fileFunc);
+
+/*
+** get filesize of an entry
+**
+** Parameters:
+**	wvfs - pointer to archive
+**	name - file name with path
+** Returns:
+**	error code or file size on success
+** Notable error codes:
+**	WVFS_ERROR_FILE_NOT_FOUND - file does not exist
+**	WVFS_ERROR_INVALID_FILE_TYPE - filename points to non-file (e.g. directory)
+*/
+LONG wvfs_getFileSize(APTR wvfs, const CPTR name);
+
+/*
+** Read a file
+**
+** Parameters:
+**	wvfs - pointer to archive
+**	dest - pointer to destination buffer to be filled
+**	name - file name with path
+**	length - length of data to read
+**	offset - file offset from where to start reading
+** Returns:
+**	error code or bytes read on success.
+** Notable error codes:
+**	WVFS_ERROR_FILE_NOT_FOUND - file does not exist
+**	WVFS_ERROR_INVALID_FILE_TYPE - filename points to non-file (f.e. directory)
+**	WVFS_ERROR_DECOMPRESSION_ERROR - failed to decompress the file
+**	WVFS_ERROR_INVALID_READ - offset and/or length is not valid for this file
+*/
+LONG wvfs_fileRead(APTR wvfs, APTR dest, const CPTR name, ULONG length, ULONG offset);
+
+/*
+** Return description for error code
+**
+** Parameters:
+**	error_code error to be queried
+** Returns:
+**	Pointer to a string for the error description
+*/
+const CPTR wvfs_getErrorString(LONG error_code);
+
+#endif	/* WHDVFS_H */

--- a/library/whdvfs.i
+++ b/library/whdvfs.i
@@ -58,7 +58,7 @@ WVFS_HEADER	MACRO
 	; dos.FileInfoBlock
 	; provided function regEntry will copy the information to private
 	; storage
-	; LONG cont regEntry(const CPTR name, const APTR fib)
+	; LONG cont regEntry(const CPTR name, const struct FileInfoBlock *fib)
 	; parameters:
 	;	name - full path + dir/file name
 	;	fib - filled FileInfoBlock structure
@@ -84,7 +84,7 @@ WVFS_HEADER	MACRO
 
 	; get filesize of an entry
 	; return positive numbers for size, negative numbers on error
-	; ULONG size getFileSize(APTR wvfs, const CPTR filename)
+	; LONG size getFileSize(APTR wvfs, const CPTR filename)
 	APTR	wvfs_getFileSize
 
 	; read part of file into given memory
@@ -104,6 +104,20 @@ WVFS_HEADER	MACRO
 ;=============================================================================
 
 	BITDEF WVFS,Dummy,0		; none yet
+
+;=============================================================================
+; Errorcodes returned from API functions
+;=============================================================================
+
+WVFS_ERROR_INVALID_FORMAT = -1		 ; invalid structure of supported file format
+WVFS_ERROR_UNSUPPORTED_FORMAT = -2	 ; file format is not supported
+WVFS_ERROR_MEMORY_ALLOCATION_FAILED = -3 ; failed to allocate memory
+WVFS_ERROR_FILE_NOT_FOUND = -4		 ; file does not exist
+WVFS_ERROR_NON_AMIGA_ARCHIVE = -5	 ; file misses Amiga specific meta information
+WVFS_ERROR_INVALID_FILE_TYPE = -6	 ; filename points to non-file (e.g. directory)
+WVFS_ERROR_DECOMPRESSION_ERROR = -7	 ; failed to decompress a file
+WVFS_ERROR_INVALID_READ = -8		 ; offset and/or length is not valid for this file
+WVFS_ERROR_OPERATION_CANCELED = -9	 ; callback returned stop condition
 
 ;=============================================================================
 

--- a/testing/test.c
+++ b/testing/test.c
@@ -143,7 +143,7 @@ int main(int argc,char **argv)
 		printf("----------------------------------------------------------------------------\n");
 		printf("FileCache:\n");
 		ret=archivefs_fileCache(archive,test_allocFunc);
-		if (ret && ret!=ARCHIVEFS_ERROR_OPERATION_CANCELED)
+		if (ret && ret!=WVFS_ERROR_OPERATION_CANCELED)
 		{
 			printf("archivefs_fileCache failed with code %d (%s)\n",ret,archivefs_getErrorString(ret));
 			return 0;
@@ -177,7 +177,7 @@ int main(int argc,char **argv)
 		printf("----------------------------------------------------------------------------\n");
 		printf("Examine:\n");
 		ret=archivefs_dirCache(archive,test_registerFunc);
-		if (ret && ret!=ARCHIVEFS_ERROR_OPERATION_CANCELED)
+		if (ret && ret!=WVFS_ERROR_OPERATION_CANCELED)
 		{
 			printf("archivefs_dirCache failed with code %d (%s)\n",ret,archivefs_getErrorString(ret));
 			return 0;


### PR DESCRIPTION
This is to solve issue #9 .
Error codes are moved to generic vfs include file to allow WHDLoad to use them.
Could you review?